### PR TITLE
Fix Task<TResult>.TrySetResult(TResult result) method to set result after transition to Completed state but before sending signal about completion

### DIFF
--- a/src/NETStandard.WindowsCE/Threading/Tasks/Future.cs
+++ b/src/NETStandard.WindowsCE/Threading/Tasks/Future.cs
@@ -257,7 +257,12 @@ namespace System.Threading.Tasks
 
         internal bool TrySetResult(TResult result)
         {
-            return TrySetCompleted(() => _result = result);
+            if (!AtomicStateUpdate(TASK_STATE_STARTED | TASK_STATE_RAN_TO_COMPLETION, TASK_STATE_COMPLETED_MASK))
+                return false;
+
+            _result = result;
+            SendCompletedSignal();
+            return true;
         }
 
         #endregion

--- a/src/NETStandard.WindowsCE/Threading/Tasks/Future.cs
+++ b/src/NETStandard.WindowsCE/Threading/Tasks/Future.cs
@@ -257,11 +257,7 @@ namespace System.Threading.Tasks
 
         internal bool TrySetResult(TResult result)
         {
-            if (!TrySetCompleted())
-                return false;
-
-            _result = result;
-            return true;
+            return TrySetCompleted(() => _result = result);
         }
 
         #endregion

--- a/src/NETStandard.WindowsCE/Threading/Tasks/Task.cs
+++ b/src/NETStandard.WindowsCE/Threading/Tasks/Task.cs
@@ -541,11 +541,12 @@ namespace System.Threading.Tasks
         }
 
         // Atomically mark a Task as completed while making sure that it is not already completed.
-        internal bool TrySetCompleted()
+        internal bool TrySetCompleted(Action action = null)
         {
             if (!AtomicStateUpdate(TASK_STATE_STARTED | TASK_STATE_RAN_TO_COMPLETION, TASK_STATE_COMPLETED_MASK))
                 return false;
-
+            
+            action?.Invoke();
             SendCompletedSignal();
             return true;
         }

--- a/src/NETStandard.WindowsCE/Threading/Tasks/Task.cs
+++ b/src/NETStandard.WindowsCE/Threading/Tasks/Task.cs
@@ -61,7 +61,7 @@ namespace System.Threading.Tasks
         internal const int TASK_STATE_WAITINGFORACTIVATION = 0x2000000;                        //bin: 0000 0010 0000 0000 0000 0000 0000 0000
 
         // A mask for all of the final states a task may be in
-        private const int TASK_STATE_COMPLETED_MASK = TASK_STATE_CANCELED | TASK_STATE_FAULTED | TASK_STATE_RAN_TO_COMPLETION;
+        private protected const int TASK_STATE_COMPLETED_MASK = TASK_STATE_CANCELED | TASK_STATE_FAULTED | TASK_STATE_RAN_TO_COMPLETION;
 
         #region Properties
 
@@ -497,7 +497,7 @@ namespace System.Threading.Tasks
 
         // Atomically OR-in newBits to _stateFlags, while making sure that
         // no illegalBits are set.  Returns true on success, false on failure.
-        private bool AtomicStateUpdate(int newBits, int illegalBits)
+        private protected bool AtomicStateUpdate(int newBits, int illegalBits)
         {
             SpinWait sw = new SpinWait();
             do
@@ -541,12 +541,11 @@ namespace System.Threading.Tasks
         }
 
         // Atomically mark a Task as completed while making sure that it is not already completed.
-        internal bool TrySetCompleted(Action action = null)
+        internal bool TrySetCompleted()
         {
             if (!AtomicStateUpdate(TASK_STATE_STARTED | TASK_STATE_RAN_TO_COMPLETION, TASK_STATE_COMPLETED_MASK))
                 return false;
             
-            action?.Invoke();
             SendCompletedSignal();
             return true;
         }
@@ -602,7 +601,7 @@ namespace System.Threading.Tasks
         }
 
         // Send signal to completed event handler and execute callback
-        private void SendCompletedSignal()
+        private protected void SendCompletedSignal()
         {
             // TODO: Avoid initialization race
             var contingentProperties = m_contingentProperties;


### PR DESCRIPTION
Fix issue #47 